### PR TITLE
[dispenser] Add a greedy assignment strategy

### DIFF
--- a/lib/dispenser/assignment_strategy/greedy.ex
+++ b/lib/dispenser/assignment_strategy/greedy.ex
@@ -23,7 +23,12 @@ defmodule Dispenser.AssignmentStrategy.Greedy do
     {assigned_demands, remaining_demands}
   end
 
-  defp do_assign([{subscriber, demand} | other_demands], %Demands{} = assigned_demands, %Demands{} = remaining_demands, event_count) do
+  defp do_assign(
+         [{subscriber, demand} | other_demands],
+         %Demands{} = assigned_demands,
+         %Demands{} = remaining_demands,
+         event_count
+       ) do
     assigned_count = min(demand, event_count)
 
     new_assignments = Demands.add(assigned_demands, subscriber, assigned_count)

--- a/lib/dispenser/assignment_strategy/greedy.ex
+++ b/lib/dispenser/assignment_strategy/greedy.ex
@@ -1,0 +1,34 @@
+defmodule Dispenser.AssignmentStrategy.Greedy do
+  @moduledoc """
+  The `Greedy` `AssignmentStrategy` assigns events to subscribers filling their demand before considering other
+  subscribers. On each call to `assign`, the order of subscribers is shuffled, meaning that in the long run
+  all of the subscribers will get a roughly equal amount of work, but in the short run, work is assigned in a
+  more bursty fashion.
+  """
+
+  alias Dispenser.AssignmentStrategy
+  alias Dispenser.Demands
+
+  @behaviour AssignmentStrategy
+
+  @impl AssignmentStrategy
+  def assign(%Demands{} = demands, event_count) do
+    demands
+    |> Demands.subscribers()
+    |> Enum.shuffle()
+    |> do_assign(Demands.new(), demands, event_count)
+  end
+
+  defp do_assign([], %Demands{} = assigned_demands, %Demands{} = remaining_demands, _event_count) do
+    {assigned_demands, remaining_demands}
+  end
+
+  defp do_assign([{subscriber, demand} | other_demands], %Demands{} = assigned_demands, %Demands{} = remaining_demands, event_count) do
+    assigned_count = min(demand, event_count)
+
+    new_assignments = Demands.add(assigned_demands, subscriber, assigned_count)
+    remaining_demands = Demands.subtract(remaining_demands, subscriber, assigned_count)
+
+    do_assign(other_demands, new_assignments, remaining_demands, event_count - assigned_count)
+  end
+end

--- a/test/dispenser/assignment_strategy/greedy_test.exs
+++ b/test/dispenser/assignment_strategy/greedy_test.exs
@@ -1,0 +1,94 @@
+defmodule Dispenser.AssignmentStrategy.GreedyTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  alias Dispenser.AssignmentStrategy
+  alias Dispenser.{Demands, Fakes}
+
+  describe "greedy assignment strategy" do
+    test "works with a single subscriber with demand to spare" do
+      subscription1 = Fakes.create_subscription()
+      demands = Demands.new()
+      |> Demands.add(subscription1, 10)
+
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 3)
+
+      assert Demands.get(assigned_demands, subscription1) == 3
+      assert Demands.get(remaining_demands, subscription1) == 7
+    end
+
+    test "works with a single subscriber without enough demand" do
+      subscription1 = Fakes.create_subscription()
+      demands = Demands.new()
+      |> Demands.add(subscription1, 10)
+
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 15)
+
+      # everything got its full demand assigned
+      assert assigned_demands == demands
+      assert remaining_demands == Demands.new()
+    end
+
+    test "works with two subscribers fully exhausted" do
+      subscription1 = Fakes.create_subscription()
+      subscription2 = Fakes.create_subscription()
+
+      demands = Demands.new()
+      |> Demands.add(subscription1, 10)
+      |> Demands.add(subscription2, 10)
+
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 25)
+
+      # everything got its full demand assigned
+      assert assigned_demands == demands
+      assert remaining_demands == Demands.new()
+    end
+
+    test "works with two subscribers, satisfiable by one" do
+      subscription1 = Fakes.create_subscription()
+      subscription2 = Fakes.create_subscription()
+
+      demands = Demands.new()
+      |> Demands.add(subscription1, 10)
+      |> Demands.add(subscription2, 10)
+
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 3)
+
+      # one of them got the partial demand
+      assert Demands.get(assigned_demands, subscription1) == 3 or Demands.get(assigned_demands, subscription2) == 3
+      assert Demands.size(assigned_demands) == 1
+
+      # the remaining demands stuck around
+      assert Demands.total(remaining_demands) == 17
+      assert Demands.size(remaining_demands) == 2
+    end
+
+    test "works with two subscribers, satisfiable with both" do
+      subscription1 = Fakes.create_subscription()
+      subscription2 = Fakes.create_subscription()
+
+      demands = Demands.new()
+      |> Demands.add(subscription1, 10)
+      |> Demands.add(subscription2, 10)
+
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 16)
+
+      # Both should have gotten work
+      assert Demands.get(assigned_demands, subscription1) >= 6
+      assert Demands.get(assigned_demands, subscription2) >= 6
+      assert Demands.total(assigned_demands) == 16
+      assert Demands.size(assigned_demands) == 2
+
+      # one of them stuck around in remaining_demands
+      assert Demands.total(remaining_demands) == 4
+      assert Demands.size(remaining_demands) == 1
+    end
+
+    test "works with no subscribers" do
+      {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(Demands.new(), 10)
+
+      assert assigned_demands == Demands.new()
+      assert remaining_demands == Demands.new()
+    end
+  end
+end

--- a/test/dispenser/assignment_strategy/greedy_test.exs
+++ b/test/dispenser/assignment_strategy/greedy_test.exs
@@ -8,8 +8,10 @@ defmodule Dispenser.AssignmentStrategy.GreedyTest do
   describe "greedy assignment strategy" do
     test "works with a single subscriber with demand to spare" do
       subscription1 = Fakes.create_subscription()
-      demands = Demands.new()
-      |> Demands.add(subscription1, 10)
+
+      demands =
+        Demands.new()
+        |> Demands.add(subscription1, 10)
 
       {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 3)
 
@@ -19,8 +21,10 @@ defmodule Dispenser.AssignmentStrategy.GreedyTest do
 
     test "works with a single subscriber without enough demand" do
       subscription1 = Fakes.create_subscription()
-      demands = Demands.new()
-      |> Demands.add(subscription1, 10)
+
+      demands =
+        Demands.new()
+        |> Demands.add(subscription1, 10)
 
       {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 15)
 
@@ -33,9 +37,10 @@ defmodule Dispenser.AssignmentStrategy.GreedyTest do
       subscription1 = Fakes.create_subscription()
       subscription2 = Fakes.create_subscription()
 
-      demands = Demands.new()
-      |> Demands.add(subscription1, 10)
-      |> Demands.add(subscription2, 10)
+      demands =
+        Demands.new()
+        |> Demands.add(subscription1, 10)
+        |> Demands.add(subscription2, 10)
 
       {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 25)
 
@@ -48,14 +53,17 @@ defmodule Dispenser.AssignmentStrategy.GreedyTest do
       subscription1 = Fakes.create_subscription()
       subscription2 = Fakes.create_subscription()
 
-      demands = Demands.new()
-      |> Demands.add(subscription1, 10)
-      |> Demands.add(subscription2, 10)
+      demands =
+        Demands.new()
+        |> Demands.add(subscription1, 10)
+        |> Demands.add(subscription2, 10)
 
       {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 3)
 
       # one of them got the partial demand
-      assert Demands.get(assigned_demands, subscription1) == 3 or Demands.get(assigned_demands, subscription2) == 3
+      assert Demands.get(assigned_demands, subscription1) == 3 or
+               Demands.get(assigned_demands, subscription2) == 3
+
       assert Demands.size(assigned_demands) == 1
 
       # the remaining demands stuck around
@@ -67,9 +75,10 @@ defmodule Dispenser.AssignmentStrategy.GreedyTest do
       subscription1 = Fakes.create_subscription()
       subscription2 = Fakes.create_subscription()
 
-      demands = Demands.new()
-      |> Demands.add(subscription1, 10)
-      |> Demands.add(subscription2, 10)
+      demands =
+        Demands.new()
+        |> Demands.add(subscription1, 10)
+        |> Demands.add(subscription2, 10)
 
       {assigned_demands, remaining_demands} = AssignmentStrategy.Greedy.assign(demands, 16)
 


### PR DESCRIPTION
This adds a new assignment strategy which does the opposite of the Even strategy: it will try to assign to subscribers to fill their demand, and only use more if the first ones chosen did not fit the bill. It maintains a random selection order to avoid a persistent bias.